### PR TITLE
fix(java): Fix flakiness in CollectionSerializersTest#tesPriorityQueueSerializer

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
@@ -374,7 +374,7 @@ public class CollectionSerializersTest extends ForyTestBase {
   public void tesPriorityQueueSerializer(Fory fory) {
     ImmutableList<String> list = ImmutableList.of("a", "b", "c");
     PriorityQueue<String> copy = fory.copy(new PriorityQueue<>(list));
-    Assert.assertEquals(ImmutableList.copyOf(copy), list);
+    Assert.assertEquals(ImmutableList.sortedCopyOf(copy), list);
   }
 
   @Test

--- a/python/README.md
+++ b/python/README.md
@@ -547,17 +547,17 @@ fory.register(MyClass, typename="my.package.MyClass", serializer=custom_serializ
 
 ### Language Modes Comparison
 
-| Feature               | Python Mode (`xlang=False`) | Cross-Language Mode (`xlang=True`)    |
-| --------------------- | --------------------------- | ------------------------------------- |
-| **Use Case**          | Pure Python applications    | Multi-language systems                |
-| **Compatibility**     | Python only                 | Java, Go, Rust, C++, JavaScript, etc. |
-| **Supported Types**   | All Python types            | Cross-language compatible types only  |
-| **Functions/Lambdas** | ✓ Supported                 | ✗ Not allowed                         |
-| **Local Classes**     | ✓ Supported                 | ✗ Not allowed                         |
-| **Dynamic Classes**   | ✓ Supported                 | ✗ Not allowed                         |
-| **Schema Evolution**  | ✓ Supported (with `compatible=True`)| ✓ Supported (with `compatible=True`)  |
-| **Performance**       | Extremely fast              | Very fast                             |
-| **Data Size**         | Compact                     | Compact with type metadata            |
+| Feature               | Python Mode (`xlang=False`)          | Cross-Language Mode (`xlang=True`)    |
+| --------------------- | ------------------------------------ | ------------------------------------- |
+| **Use Case**          | Pure Python applications             | Multi-language systems                |
+| **Compatibility**     | Python only                          | Java, Go, Rust, C++, JavaScript, etc. |
+| **Supported Types**   | All Python types                     | Cross-language compatible types only  |
+| **Functions/Lambdas** | ✓ Supported                          | ✗ Not allowed                         |
+| **Local Classes**     | ✓ Supported                          | ✗ Not allowed                         |
+| **Dynamic Classes**   | ✓ Supported                          | ✗ Not allowed                         |
+| **Schema Evolution**  | ✓ Supported (with `compatible=True`) | ✓ Supported (with `compatible=True`)  |
+| **Performance**       | Extremely fast                       | Very fast                             |
+| **Data Size**         | Compact                              | Compact with type metadata            |
 
 #### Python Mode (`xlang=False`)
 


### PR DESCRIPTION
## What does this PR do?

`CollectionSerializersTest#tesPriorityQueueSerializer` tries to compare the content of a PriorityQueue to an expected ImmutableList using `ImmutableList.copyOf()`, but the PriorityQueue is based on a heap and does not guarrentee any ordering in its underlying data structures. Therefore the `toArray()` method which `copyOf()` invokes will return non-deterministic results. 

We can reproduce the flakiness with [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.serializer.collection.CollectionSerializersTest#tesPriorityQueueSerializer
```
This PR uses `sortedCopyOf()` instead to enforce the ordering of elememts in the new ImmutableList, which removes the flakiness. 

This change does not weaken the test in any way because a PriorityQueue preserves natural ordering in the absence of a Comparator (when using `poll()`, for example) which is equivalent to sorting the elements in this case.

## Does this PR introduce any user-facing change?

No

