### PR TITLE
fix(java): Fix flakiness in LazyMapTest#testMap

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/collection/LazyMapTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/collection/LazyMapTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertTrue;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.fory.Fory;
 import org.apache.fory.ForyTestBase;
@@ -37,7 +38,7 @@ public class LazyMapTest extends ForyTestBase {
 
   @Test
   public void testMap() throws NoSuchFieldException, IllegalAccessException {
-    Map<String, Integer> map = new HashMap<>();
+    Map<String, Integer> map = new LinkedHashMap<>();
     map.put("k1", 1);
     map.put("k2", 2);
     LazyMap<String, Integer> map1 = new LazyMap<>(new ArrayList<>(map.entrySet()));

--- a/python/README.md
+++ b/python/README.md
@@ -547,17 +547,17 @@ fory.register(MyClass, typename="my.package.MyClass", serializer=custom_serializ
 
 ### Language Modes Comparison
 
-| Feature               | Python Mode (`xlang=False`) | Cross-Language Mode (`xlang=True`)    |
-| --------------------- | --------------------------- | ------------------------------------- |
-| **Use Case**          | Pure Python applications    | Multi-language systems                |
-| **Compatibility**     | Python only                 | Java, Go, Rust, C++, JavaScript, etc. |
-| **Supported Types**   | All Python types            | Cross-language compatible types only  |
-| **Functions/Lambdas** | ✓ Supported                 | ✗ Not allowed                         |
-| **Local Classes**     | ✓ Supported                 | ✗ Not allowed                         |
-| **Dynamic Classes**   | ✓ Supported                 | ✗ Not allowed                         |
-| **Schema Evolution**  | ✓ Supported (with `compatible=True`)| ✓ Supported (with `compatible=True`)  |
-| **Performance**       | Extremely fast              | Very fast                             |
-| **Data Size**         | Compact                     | Compact with type metadata            |
+| Feature               | Python Mode (`xlang=False`)          | Cross-Language Mode (`xlang=True`)    |
+| --------------------- | ------------------------------------ | ------------------------------------- |
+| **Use Case**          | Pure Python applications             | Multi-language systems                |
+| **Compatibility**     | Python only                          | Java, Go, Rust, C++, JavaScript, etc. |
+| **Supported Types**   | All Python types                     | Cross-language compatible types only  |
+| **Functions/Lambdas** | ✓ Supported                          | ✗ Not allowed                         |
+| **Local Classes**     | ✓ Supported                          | ✗ Not allowed                         |
+| **Dynamic Classes**   | ✓ Supported                          | ✗ Not allowed                         |
+| **Schema Evolution**  | ✓ Supported (with `compatible=True`) | ✓ Supported (with `compatible=True`)  |
+| **Performance**       | Extremely fast                       | Very fast                             |
+| **Data Size**         | Compact                              | Compact with type metadata            |
 
 #### Python Mode (`xlang=False`)
 


### PR DESCRIPTION
## What does this PR do?

`LazyMapTest#testMap` assumes that `HashMap` maintains constant ordering, which can lead to non-deterministic failures.

> This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.

We can reproduce the non-deterministic failures with [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.collection.LazyMapTest#testMap
```

Instead of `HashMap`, use `LinkedHashMap` to gurrantee constant ordering over time. 

## Does this PR introduce any user-facing change?

No
