### PR TITLE
fix(java): Fix flakiness in ForyCopyTest#mutableObjectCopyTest

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -243,7 +243,7 @@ public class ForyCopyTest extends ForyTestBase {
     ChildArrayDeque<String> list = new ChildArrayDeque<>();
     list.addAll(data);
     Assert.assertEquals(data, ImmutableList.copyOf(fory.copy(list)));
-    Assert.assertEquals(data, ImmutableList.copyOf(new PriorityQueue<>(data)));
+    Assert.assertEquals(data, ImmutableList.sortedCopyOf(new PriorityQueue<>(data)));
   }
 
   private void primitiveCopyTest() {


### PR DESCRIPTION
## What does this PR do?

`ForyCopyTest#mutableObjectCopyTest` assumes that PriorityQueues gurrantees natural ordering in its underlying structure, which can lead to non-deterministic test results. 

> This class and its iterator implement all of the optional methods of the [Collection](https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html) and [Iterator](https://docs.oracle.com/javase/8/docs/api/java/util/Iterator.html) interfaces. The Iterator provided in method [iterator()](https://docs.oracle.com/javase/8/docs/api/java/util/PriorityQueue.html#iterator--) is not guaranteed to traverse the elements of the priority queue in any particular order.

We can reproduce the flakiness with [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.ForyCopyTest.mutableObjectCopyTest
```
This PR uses `sortedCopyOf()` instead to enforce the ordering of elememts in the new ImmutableList, which removes the flakiness. 

Similar to #2693

## Does this PR introduce any user-facing change?

No
