### PR TITLE
fix(java): Fix flakiness in MetaContextTest#testShareClassName and MetaContextTest#testShareClassDefCompatible

### DIFF
--- a/java/fory-test-core/src/main/java/org/apache/fory/test/bean/BeanA.java
+++ b/java/fory-test-core/src/main/java/org/apache/fory/test/bean/BeanA.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -118,7 +118,7 @@ public class BeanA implements Serializable {
         beanA.setBeanBList(beanBList);
       }
       {
-        Map<String, BeanB> stringBeanBMap = new HashMap<>();
+        Map<String, BeanB> stringBeanBMap = new LinkedHashMap<>();
         for (int i = 0; i < arrSize; i++) {
           stringBeanBMap.put("key" + i, BeanB.createBeanB(arrSize));
         }


### PR DESCRIPTION
## What does this PR do?

These tests in `MetaContextTest` create a `BeanA` instance for testing, which contains a HashMap. When calling `write(MemoryBuffer buffer, T value)` in `MapLikeSerializer.java`, the method assumes that the HashMap maintains constant ordering of elements. This can cause `Assert.assertEquals(fory.serialize(o), bytes)` to fail non-deterministically in `MetaContextTest.java`. This PR is similar to #2692. 

> This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.

We can reproduce the flakiness with [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.resolver.MetaContextTest#testShareClassName

mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.resolver.MetaContextTest#testShareClassDefCompatible
```

We can trace the HashMap causing failures with 
```
mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:debug
```

This PR solves the issue by using a LinkedHashMap in `BeanA` which promises deterministic ordering.

## Does this PR introduce any user-facing change?

No
