### PR TITLE
fix(java): Fix flakiness in CollectionSerializersTest#testCollectionFieldSerializers, CollectionSerializersTest#testCollectionFieldSerializersCopy and ProtocolInteroperabilityTest#testComplexCollection

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/serializer/ProtocolInteroperabilityTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/ProtocolInteroperabilityTest.java
@@ -217,7 +217,19 @@ public class ProtocolInteroperabilityTest extends ForyTestBase {
   public void testComplexCollection(Fory fory, Fory foryJIT) {
     CollectionSerializersTest.CollectionFieldsClass o =
         CollectionSerializersTest.createCollectionFieldsObject();
-    roundCheck(fory, foryJIT, o, Object::toString);
+    roundCheck(
+        fory,
+        foryJIT,
+        o,
+        obj -> {
+          try {
+            CollectionSerializersTest.testCollectionFieldsObjectEqual(
+                (CollectionSerializersTest.CollectionFieldsClass) obj, o);
+            return "OK";
+          } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   @Test(dataProvider = "fory")


### PR DESCRIPTION
## What does this PR do?

These tests create a `CollectionFieldsClass` that contains HashSet and PriorityQueue fields, which do not guarantee deterministic ordering. So `toString()` comparisons could lead to non-deterministic failures.

Quotes from Java's summary of HashSet and PriorityQueue:

>  It makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time.

> The Iterator provided in method [iterator()](https://docs.oracle.com/javase/8/docs/api/java/util/PriorityQueue.html#iterator--) is not guaranteed to traverse the elements of the priority queue in any particular order. If you need ordered traversal, consider using Arrays.sort(pq.toArray()).

We can reproduce the flakiness with [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.serializer.collection.CollectionSerializersTest#testCollectionFieldSerializers

mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.serializer.collection.CollectionSerializersTest#testCollectionFieldSerializersCopy

mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.serializer.ProtocolInteroperabilityTest#testComplexCollection
```

Since `toString()` just dumps all the fields, we can solve the problem by iteratively comparing fields with deterministic ordering, and manually compare everything else after sorting.

In particular, `CollectionSerializersTest.testCollectionFieldsObjectEqual` is made public, so that `ProtocolInteroperabilityTest` can reuse the solution.

## Does this PR introduce any user-facing change?

No